### PR TITLE
Fix insecure YouTube links.

### DIFF
--- a/source/articles/2011-02-february-ministry-report.html.markdown
+++ b/source/articles/2011-02-february-ministry-report.html.markdown
@@ -13,4 +13,4 @@ For those of you who haven't seen it yet, here's our February ministry report.
 
 READMORE
 
-<iframe title="YouTube video player" width="450" height="273" src="http://www.youtube.com/embed/Nql1AaBi514" frameborder="0" allowfullscreen></iframe>
+<iframe width="560" height="315" src="https://www.youtube.com/embed/Nql1AaBi514" frameborder="0" allowfullscreen></iframe>

--- a/source/articles/2011-03-march-video-report.html.markdown
+++ b/source/articles/2011-03-march-video-report.html.markdown
@@ -20,4 +20,4 @@ READMORE
 
 Thanks for keeping our ministry in your prayers!
 
-<iframe title="YouTube video player" width="450" height="273" src="http://www.youtube.com/embed/pR2NILBTW5A" frameborder="0" allowfullscreen></iframe>
+<iframe width="560" height="315" src="https://www.youtube.com/embed/pR2NILBTW5A" frameborder="0" allowfullscreen></iframe>

--- a/source/articles/2011-04-video-report-and-other-news.html.markdown
+++ b/source/articles/2011-04-video-report-and-other-news.html.markdown
@@ -14,7 +14,7 @@ Better late than never? I suppose the truth of that statement depends on the sit
 
 READMORE
 
-<iframe title="YouTube video player" width="450" height="273" src="http://www.youtube.com/embed/Czj5jzdAoa0" frameborder="0" allowfullscreen></iframe>
+<iframe width="560" height="315" src="https://www.youtube.com/embed/Czj5jzdAoa0" frameborder="0" allowfullscreen></iframe>
 
 ### New OFR Available
 

--- a/source/articles/2011-08-news-from-the-steeles.html.markdown
+++ b/source/articles/2011-08-news-from-the-steeles.html.markdown
@@ -16,6 +16,6 @@ READMORE
 
 We've just posted a couple of new videos to YouTube which we'd like to share with you. In the first, our two oldest daughters quote 1 John 4:7-11. Also included in this video is an explanation of the Scripture memory technique that our family uses to help our kids learn Bible passages with confidence. The second video is our latest ETO Video Report which contains some new information about Bible First development. We hope you enjoy these videos and we appreciate your prayers for our family and ministry in Ukraine.
 
-<iframe src="http://www.youtube.com/embed/EAanMSxoUCA" frameborder="0" width="450" height="286"></iframe>
+<iframe width="560" height="315" src="https://www.youtube.com/embed/EAanMSxoUCA" frameborder="0" allowfullscreen></iframe>
 
-<iframe src="http://www.youtube.com/embed/L-V4f036lxU" frameborder="0" width="450" height="286"></iframe>
+<iframe width="560" height="315" src="https://www.youtube.com/embed/L-V4f036lxU" frameborder="0" allowfullscreen></iframe>

--- a/source/articles/2012-02-abby-beka-hebrews-11.html.markdown
+++ b/source/articles/2012-02-abby-beka-hebrews-11.html.markdown
@@ -13,4 +13,4 @@ Check out our latest video of Abigail and Rebekah quoting Scripture! Due to our 
 
 READMORE
 
-<iframe src="http://www.youtube.com/embed/UFzM_Ze0ehU" frameborder="0" width="560" height="315"></iframe>
+<iframe width="560" height="315" src="https://www.youtube.com/embed/UFzM_Ze0ehU" frameborder="0" allowfullscreen></iframe>


### PR DESCRIPTION
Because the site is served over HTTPS, Chrome (and presumably other browsers) refuses to load embedded scripts that are insecure (HTTP). This results in a blank spot where, in our case, a YouTube video was supposed to be displayed.

![screenshot 2017-07-14 09 20 21](https://user-images.githubusercontent.com/615841/28200814-c93753e8-6876-11e7-84b5-ab2682dde3c8.png)