### PR TITLE
Add MailChimp Subscribe Pop-up

### DIFF
--- a/source/partials/_head_contents.html.haml
+++ b/source/partials/_head_contents.html.haml
@@ -36,6 +36,7 @@
 %title= full_title(page_title, site_title)
 
 = partial "partials/analytics" if production?
+= partial "partials/subscribe_popup"
 = tag "link", rel: "apple-touch-icon", href: image_path("apple-touch-icon.png")
 = feed_tag :rss, "#{site_url}/feed.xml", title: "RSS Feed"
 = stylesheet_link_tag :site

--- a/source/partials/_head_contents.html.haml
+++ b/source/partials/_head_contents.html.haml
@@ -27,7 +27,7 @@
 - if content_for?(:og_tags)
   = yield_content :og_tags
 - else
-  = tag "meta", property: "og:url", content: site_url
+  = tag "meta", property: "og:url", content: og_url
   = tag "meta", property: "og:type", content: "blog"
   = tag "meta", property: "og:title", content: og_title
   = tag "meta", property: "og:description", content: og_desc

--- a/source/partials/_subscribe_popup.html.haml
+++ b/source/partials/_subscribe_popup.html.haml
@@ -1,0 +1,11 @@
+%script{ "data-dojo-config" => "usePlainJson: true, isDebug: false",
+  :src => "//downloads.mailchimp.com/js/signup-forms/popup/embed.js",
+  :type => "text/javascript" }
+:javascript
+  require(["mojo/signup-forms/Loader"], function(L) {
+    L.start({
+      "baseUrl":"mc.us6.list-manage.com",
+      "uuid":"1e0c65850b60905f65b151819",
+      "lid":"97b9f6a559"
+    })
+  })


### PR DESCRIPTION
This PR adds a subscriber pop-up for our MailChimp email list.

* The pop-up is added using a snippet of JavaScript.
* Can be updated in future via MailChimp dashboard without having to edit code in-site.
* Only appears once for new viewers. Will not appear again for one year or unless the viewer dumps cookies.
* Currently using a time-based trigger of 20 seconds.

![screenshot 2018-01-05 09 12 09](https://user-images.githubusercontent.com/615841/34598974-99c493f8-f1f8-11e7-815d-0bc8fc3e0206.png)

**Reference**
* https://blog.mailchimp.com/fresh-new-pop-up-forms-to-grow-your-list
  