### PR TITLE
Fix webfontloader

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,15 +39,14 @@
     "gulp-util": "^3.0.8",
     "run-sequence": "^2.2.1",
     "vinyl-buffer": "^1.0.1",
-    "vinyl-source-stream": "^2.0.0",
-    "webfontloader": "^1.6.28"
+    "vinyl-source-stream": "^2.0.0"
   },
   "dependencies": {
     "bourbon": "^5.0.0-beta.8",
     "bourbon-neat": "^2.1.0",
     "jquery": "^3.2.1",
     "moment": "^2.20.1",
-    "webfontloader": "^1.6.27"
+    "webfontloader": "^1.6.28"
   },
   "engines": {
     "node": ">= 6.9.4"

--- a/source/layouts/home.haml
+++ b/source/layouts/home.haml
@@ -29,4 +29,5 @@
           = yield
 
     = partial "partials/footer"
+    = partial "partials/subscribe_popup"
     = partial "partials/statcounter" if production?

--- a/source/layouts/layout.haml
+++ b/source/layouts/layout.haml
@@ -10,4 +10,5 @@
       = yield
 
     = partial "partials/footer"
+    = partial "partials/subscribe_popup"
     = partial "partials/statcounter" if production?

--- a/source/partials/_head_contents.html.haml
+++ b/source/partials/_head_contents.html.haml
@@ -36,7 +36,6 @@
 %title= full_title(page_title, site_title)
 
 = partial "partials/analytics" if production?
-= partial "partials/subscribe_popup"
 = tag "link", rel: "apple-touch-icon", href: image_path("apple-touch-icon.png")
 = feed_tag :rss, "#{site_url}/feed.xml", title: "RSS Feed"
 = stylesheet_link_tag :site

--- a/source/partials/_head_contents.html.haml
+++ b/source/partials/_head_contents.html.haml
@@ -39,5 +39,5 @@
 = tag "link", rel: "apple-touch-icon", href: image_path("apple-touch-icon.png")
 = feed_tag :rss, "#{site_url}/feed.xml", title: "RSS Feed"
 = stylesheet_link_tag :site
-= javascript_include_tag :bundle, async: !development?
+= javascript_include_tag :bundle
 = javascript_include_tag "https://use.fontawesome.com/releases/v5.0.2/js/all.js", defer: true


### PR DESCRIPTION
When I previously added the script for MailChimp's subscriber popup, this somehow broke webfontloader. As a result, the Lato font used for site headers was not being loaded at all.

The solution turned out to be a combination of the order in which the scripts were called (the popup needed to come after the main JS bundle) and also removing the async call for the main JS bundle.